### PR TITLE
Set initial zoom level to 500 percent

### DIFF
--- a/js/cuekey.js
+++ b/js/cuekey.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const zoomMin = 50;
     const zoomMax = 500;
     const zoomIncrement = 50;
-    const zoomDefault = 200;
+    const zoomDefault = 500;
 
     const updateZoom = () => {
         keyPanel.style.transform = `scale(${zoom / 100})`;


### PR DESCRIPTION
## Summary
- set the default zoom value to 500% so the key panel loads fully zoomed in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9177fd7708331b012bcf5892f3ee3